### PR TITLE
Add LegacyDoc AI to extensions

### DIFF
--- a/src/content/resources/extensions/legacydoc-ai.md
+++ b/src/content/resources/extensions/legacydoc-ai.md
@@ -1,0 +1,23 @@
+---
+name: LegacyDoc AI
+description: VS Code extension that generates AI code audit reports, JSDoc, Markdown docs, and Mermaid architecture maps from your codebase. BYOK to your AI provider.
+categorySlug: extensions
+link: "https://www.romanticode.com/legacydoc-ai/"
+iconUrl: "https://www.romanticode.com/images/legacydoc-icon-512.png"
+previewImage: "https://www.romanticode.com/og-default.png"
+type: extension
+pricing:
+  type: freemium
+  tiers:
+    - name: Free
+      price: $0
+    - name: Pro
+      price: $29 one-time
+  details: Free tier includes 5 generations per day. Pro unlocks unlimited generations, project-level analysis, and custom prompt templates.
+tags:
+  - ai code audit
+  - documentation
+  - architecture
+  - context pack
+  - byok
+---


### PR DESCRIPTION
Adds LegacyDoc AI, a VS Code extension that generates AI code audit reports, JSDoc, Markdown docs, and Mermaid architecture diagrams from a codebase.

- File added: `src/content/resources/extensions/legacydoc-ai.md`
- Category: `extensions`
- Pricing type: `freemium`
- Schema fields used: `name`, `description`, `categorySlug`, `link`, `iconUrl`, `previewImage`, `type`, `pricing`, `tags`
- `pnpm build` passes locally

Product page: https://www.romanticode.com/legacydoc-ai/
Tool page: https://www.romanticode.com/tools/ai-code-audit-report/
Marketplace: https://marketplace.visualstudio.com/items?itemName=ruilegendoc.legacy-doc-ai

Thanks for maintaining the directory.